### PR TITLE
dynamically generated stream texts

### DIFF
--- a/frontend/src/components/App.vue
+++ b/frontend/src/components/App.vue
@@ -27,6 +27,7 @@
             model_info: {}, // {'model_name': model.__doc__},
             base_admin_url: "",
             stream_texts: window.stream_texts,
+            help_text: this.app_node.getAttribute("data-help-text"),
             text_area: null,
             delete_blocks_from_db: null,
             popup_size: null
@@ -196,9 +197,9 @@
 </script>
 <template>
     <div>
-        <div class="stream-help-text" v-if="stream_texts['help_text']">
+        <div class="stream-help-text" v-if="help_text">
             <div class="stream-help-text__title" @click="show_help=!show_help" v-text="stream_texts['Help?']"></div>
-            <div v-show="show_help" class="stream-help-text__content" v-html="stream_texts['help_text']"></div>
+            <div v-show="show_help" class="stream-help-text__content" v-html="help_text"></div>
         </div>
         
         <div class="collapse-handlers" v-if="stream.length > 1">

--- a/streamfield/fields.py
+++ b/streamfield/fields.py
@@ -4,6 +4,8 @@ from django import forms
 from django.db.models import JSONField
 from django.forms.widgets import Widget
 from django.contrib.admin.options import FORMFIELD_FOR_DBFIELD_DEFAULTS
+from django.urls import reverse_lazy
+
 from .base import StreamObject
 from .settings import (
     BLOCK_OPTIONS, 
@@ -49,7 +51,7 @@ class StreamFieldWidget(Widget):
 
     class Media:
         css = {'all': ('streamfield/streamfield_widget.css',)}
-        js = ('streamfield/streamfield_widget.js',)
+        js = (reverse_lazy("streamfield-texts"), 'streamfield/streamfield_widget.js',)
 
 
 # form field

--- a/streamfield/templates/streamfield/streamfield_texts.js
+++ b/streamfield/templates/streamfield/streamfield_texts.js
@@ -1,0 +1,13 @@
+{% load i18n %}
+
+window.stream_texts = window.stream_texts || {
+    'deleteBlock': '{% trans "Are you shure, that you want to delete this block?" %}',
+    'deleteInstance': '{% trans "Are you shure, that you want to delete this subblock?" %}',
+    'Collapse all': '{% trans "Collapse all" %}',
+    'Open all': '{% trans "Open all" %}',
+    'AddOneMore': '{% trans "Add one more" %}',
+    'Change': '{% trans "Change" %}',
+    'AddContent': '{% trans "Add content" %}',
+    'Help?': '{% trans "Help?" %}',
+    'AddNewBlock': '{% trans "Add new block" %}'
+}

--- a/streamfield/templates/streamfield/streamfield_widget.html
+++ b/streamfield/templates/streamfield/streamfield_widget.html
@@ -1,19 +1,4 @@
-{% load i18n %}
-<script type="text/javascript">
-    window.stream_texts = window.stream_texts || {
-        'deleteBlock': '{% trans "Are you shure, that you want to delete this block?" %}',
-        'deleteInstance': '{% trans "Are you shure, that you want to delete this subblock?" %}',
-        'Collapse all': '{% trans "Collapse all" %}',
-        'Open all': '{% trans "Open all" %}',
-        'AddOneMore': '{% trans "Add one more" %}',
-        'Change': '{% trans "Change" %}',
-        'AddContent': '{% trans "Add content" %}',
-        'Help?': '{% trans "Help?" %}',
-        'AddNewBlock': '{% trans "Add new block" %}',
-        'help_text': "{{ widget.value.help_text|escapejs|default:"" }}"
-    }
-</script>
-<div class="streamfield_app" id="app_{{ widget.name }}">
+<div class="streamfield_app" id="app_{{ widget.name }}" data-help-text="{{ widget.value.help_text|escapejs|default:"" }}">
     <div class="mount-node"></div>
     <textarea v-text="textarea" name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}>{% if widget.value %}{{ widget.value }}{% endif %}</textarea>
 </div>

--- a/streamfield/urls.py
+++ b/streamfield/urls.py
@@ -1,5 +1,7 @@
 from django.urls import include, path
 from django.contrib.auth.decorators import login_required
+from django.views.generic import TemplateView
+
 
 from . import views
 from .base import get_streamblocks_models
@@ -27,6 +29,11 @@ urlpatterns = [
         'admin-instance/<model_name>/<int:pk>/delete/', 
         login_required(views.delete_instance), 
         name='admin-instance-delete'
+    ),
+    path(
+        'streamfield_texts.js',
+        login_required(TemplateView.as_view(template_name="streamfield/streamfield_texts.js", content_type="text/javascript")), 
+        name='streamfield-texts',
     ),
     *admin_instance_urls
 ]


### PR DESCRIPTION
The translation of the stream texts are included in the html every time that the stream field is rendered. As a solution, I create a django view for generating that stream texts dynamically and I add that URL as a javascript media dependency in the widget. For the help text , I add the text in the attribute "data-help-text" of the streamfield_app element.